### PR TITLE
fix: any non-special chars are identifiers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1605,7 +1605,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1626,12 +1627,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1646,17 +1649,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1773,7 +1779,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1785,6 +1792,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1799,6 +1807,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1806,12 +1815,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1830,6 +1841,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1910,7 +1922,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1922,6 +1935,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2007,7 +2021,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2043,6 +2058,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2062,6 +2078,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2105,12 +2122,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -1,5 +1,5 @@
 const reWhitespace = /\s/;
-const reIdentifierChar = /[\w-]/;
+const reIdentifierChar = /[^'"@=,\*\/\s]/;
 const reNewLine = /\n/;
 
 class Lexer {

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -7,7 +7,33 @@ test('Can parse a single directive in a file with no errors', () => {
          * pageTypes = foo, bizz
          */
     `);
-    expect(errors.length).toBe(0);
+    expect(errors[0]).toBeFalsy();
+    expect(directives.length).toBe(1);
+});
+
+test('Can parse a single directive in a file with single-line comments', () => {
+    const { errors, directives } = parseDirective(`
+        /**
+         * @RootComponent
+         * pageTypes = foo, bizz
+         */
+        module.exports = () => {};
+        // a single line comment
+    `);
+    expect(errors[0]).toBeFalsy();
+    expect(directives.length).toBe(1);
+});
+
+test('Can parse a single directive in a file with source map annotations', () => {
+    const { errors, directives } = parseDirective(`
+        /**
+         * @RootComponent
+         * pageTypes = foo, bizz
+         */
+        module.exports = () => {};
+        //# sourceMappingURL=index.js.map
+    `);
+    expect(errors[0]).toBeFalsy();
     expect(directives.length).toBe(1);
 });
 


### PR DESCRIPTION
Was choking on source map comments--indeed, any character in a comment that wasn't a word character. Yikes!